### PR TITLE
Switch implementation of spectral norm

### DIFF
--- a/skillful_nowcasting/common.py
+++ b/skillful_nowcasting/common.py
@@ -4,7 +4,7 @@ import einops
 import torch
 import torch.nn.functional as F
 from torch.distributions import normal
-from torch.nn.utils import spectral_norm
+from torch.nn.utils.parametrizations import spectral_norm
 from torch.nn.modules.pixelshuffle import PixelUnshuffle
 from skillful_nowcasting.layers.utils import get_conv_layer
 from skillful_nowcasting.layers import AttentionLayer

--- a/skillful_nowcasting/discriminators.py
+++ b/skillful_nowcasting/discriminators.py
@@ -1,6 +1,6 @@
 import torch
 from torch.nn.modules.pixelshuffle import PixelUnshuffle
-from torch.nn.utils import spectral_norm
+from torch.nn.utils.parametrizations import spectral_norm
 import torch.nn.functional as F
 from skillful_nowcasting.common import DBlock
 

--- a/skillful_nowcasting/generators.py
+++ b/skillful_nowcasting/generators.py
@@ -2,7 +2,7 @@ import einops
 import torch
 import torch.nn.functional as F
 from torch.nn.modules.pixelshuffle import PixelShuffle
-from torch.nn.utils import spectral_norm
+from torch.nn.utils.parametrizations import spectral_norm
 from typing import List
 from skillful_nowcasting.common import GBlock, UpsampleGBlock
 from skillful_nowcasting.layers import ConvGRU

--- a/skillful_nowcasting/layers/ConvGRU.py
+++ b/skillful_nowcasting/layers/ConvGRU.py
@@ -1,6 +1,6 @@
 import torch
 import torch.nn.functional as F
-from torch.nn.utils import spectral_norm
+from torch.nn.utils.parametrizations import spectral_norm
 
 
 class ConvGRUCell(torch.nn.Module):


### PR DESCRIPTION
From @xinzhuang 's suggestion in #10 that should fix the NaN issue

# Pull Request

## Description

Update spectral norm to use the newer PyTorch version, which should fix the NaN issue.

Fixes #10 

## How Has This Been Tested?

Unit tests

- [ ] No
- [x] Yes

## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/nowcasting/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
