### PR TITLE
Fix: token issue when loading pretrained model

### DIFF
--- a/dgmr/hub.py
+++ b/dgmr/hub.py
@@ -148,7 +148,7 @@ class NowcastingModelHubMixin(ModelHubMixin):
                 force_download=force_download,
                 proxies=proxies,
                 resume_download=resume_download,
-                use_auth_token=use_auth_token,
+                token=use_auth_token,
                 local_files_only=local_files_only,
             )
         model = cls(**model_kwargs["config"])


### PR DESCRIPTION
# Pull Request

## Description

Fixes issue https://github.com/openclimatefix/skillful_nowcasting/issues/65

Changed the keyword argument `use_auth_token` in `hf_hub_download()` in `dgmr/hub.py` file to `token`.
According to the parameters defined in `huggingface_hub.hf_hub_download`, the argument name is `token`, not `use_auth_token`. (https://huggingface.co/docs/huggingface_hub/v0.22.0.rc0/en/package_reference/file_download#huggingface_hub.hf_hub_download)


## How Has This Been Tested?

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
```
from dgmr import DGMR, Sampler, Generator, Discriminator, LatentConditioningStack, ContextConditioningStack
access_token = "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"
model = DGMR.from_pretrained("openclimatefix/dgmr", use_auth_token=access_token)
```

- [x] Yes



_If your changes affect data processing, have you plotted any changes? i.e. have you done a quick sanity check?_

- [ ] Yes

## Checklist:

- [x] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my code and corrected any misspellings
