### PR TITLE
Pin huggingface-hub to version 0.21.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ numpy
 torchvision>=0.11.0
 pytorch_lightning
 einops
-huggingface_hub
+huggingface_hub==0.21.4


### PR DESCRIPTION
# Pull Request

## Description
`DGMR` and `NowcastingModelHubMixin` in their present form are incompatible with `huggingface-hub>=0.22`, causing a `KeyError: 'config'` when trying to load the model with `model = DGMR.from_pretrained("openclimatefix/dgmr")`. This PR pins `huggingface-hub` to the latest working version for the moment, until a full solution can be developed.


Fixes https://github.com/openclimatefix/skillful_nowcasting/issues/68

## How Has This Been Tested?

Checked that the package installs and model loads as expected.


## Checklist:

- [ ] My code follows [OCF's coding style guidelines](https://github.com/openclimatefix/.github/blob/main/coding_style.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my code and corrected any misspellings
